### PR TITLE
chore: fix typo in package.json repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https:///github.com/darcyclarke/minargs"
+    "url": "git+https://github.com/darcyclarke/minargs"
   },
   "engines": {
     "node": "^12.13.0 || ^14.15.0 || >=16"


### PR DESCRIPTION
the extra slash was tricking npmjs.com into thinking the repo was a bitbucket repository, which is fun
